### PR TITLE
Added support for Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ tip (unreleased)
 
 - Allow locking up until or only after certain dates.
 
+- Support for Python 3
+
 0.1.1 (2009.11.24)
 ------------------
 

--- a/lockdown/decutils.py
+++ b/lockdown/decutils.py
@@ -79,7 +79,7 @@ def make_middleware_decorator(middleware_class):
                         return result
                 try:
                     response = view_func(request, *args, **kwargs)
-                except Exception, e:
+                except Exception as e:
                     if hasattr(middleware, 'process_exception'):
                         result = middleware.process_exception(request, e)
                         if result is not None:

--- a/lockdown/middleware.py
+++ b/lockdown/middleware.py
@@ -24,7 +24,7 @@ def get_lockdown_form(form_path):
     module, attr = form_path[:last_dot], form_path[last_dot + 1:]
     try:
         mod = import_module(module)
-    except (ImportError, ValueError), e:
+    except (ImportError, ValueError) as e:
         raise ImproperlyConfigured('Error importing LOCKDOWN_FORM %s: "%s"'
                                    % (form_path, e))
     try:


### PR DESCRIPTION
This pull request adds support for Python 3.
The changes are fairly minor and fix the Python 3 issue mentioned at Bitbucket: https://bitbucket.org/carljm/django-lockdown/issue/8/python-3-support
I haven't tested all features of django-lockdown with Python 3, but `2to3` doesn't show additional changes and for me it works quite well with Python 3.
