### PR TITLE
Try to import import_module from standard library

### DIFF
--- a/lockdown/middleware.py
+++ b/lockdown/middleware.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-from django.utils.importlib import import_module
+from importlib import import_module
 
 from lockdown import settings
 


### PR DESCRIPTION
Try to import import_module from the standard library's importlib,
rather than django.utils.importlib,
but if that fails then import it from django.utils.importlib
(the standard library's importlib was introduced in Python 2.7,
so the Django import is necessary for Python <= 2.6).

django.utils.importlib will be removed in Django 1.9,
and importing from there raises this warning in Django 1.8:

`RemovedInDjango19Warning:
django.utils.importlib will be removed in Django 1.9.`
