### PR TITLE
Added the "extra_context" decorator argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Using the decorator
     def secret_page(request):
         # ...
 
-The decorator accepts six arguments:
+The decorator accepts seven arguments:
 
 ``form``
   The form to use for providing an admin preview, rather than the form
@@ -106,6 +106,10 @@ The decorator accepts six arguments:
 ``url_exceptions``
   A list of regular expressions for which matching urls can bypass the lockdown
   (rather than using those defined in `LOCKDOWN_URL_EXCEPTIONS`_).
+
+``extra_context``
+  A dictionary of context data that will be added to the default context data
+  passed to the template.
 
 Any further keyword arguments are passed to the admin preview form. The default
 form accepts one argument:

--- a/lockdown/middleware.py
+++ b/lockdown/middleware.py
@@ -50,7 +50,7 @@ class LockdownMiddleware(object):
 
     def __init__(self, form=None, until_date=None, after_date=None,
                  logout_key=None, session_key=None, url_exceptions=None,
-                 **form_kwargs):
+                 extra_context=None, **form_kwargs):
         """Initialize the middleware, by setting the configuration values."""
         if logout_key is None:
             logout_key = settings.LOGOUT_KEY
@@ -63,6 +63,7 @@ class LockdownMiddleware(object):
         self.logout_key = logout_key
         self.session_key = session_key
         self.url_exceptions = url_exceptions
+        self.extra_context = extra_context
 
     def process_request(self, request):
         """Check if each request is allowed to access the current resource."""
@@ -143,6 +144,9 @@ class LockdownMiddleware(object):
         page_data = {'until_date': until_date, 'after_date': after_date}
         if not hasattr(form, 'show_form') or form.show_form():
             page_data['form'] = form
+
+        if self.extra_context is not None:
+            page_data.update(self.extra_context)
 
         return render_to_response('lockdown/form.html', page_data,
                                   context_instance=RequestContext(request))

--- a/lockdown/tests/tests.py
+++ b/lockdown/tests/tests.py
@@ -257,6 +257,12 @@ class DecoratorTests(BaseTests):
         self.assertTemplateNotUsed(response, 'lockdown/form.html')
         self.assertEqual(response.content, self.locked_contents)
 
+    def test_overridden_extra_context(self):
+        """Test that locking works when overriding the extra context."""
+        url = '/locked/view/with/extra/context/'
+        response = self.client.get(url)
+        self.failUnless('foo' in response.context)
+
 
 class MiddlewareTests(BaseTests):
 

--- a/lockdown/tests/urls.py
+++ b/lockdown/tests/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^overridden/locked/view/$', views.overridden_locked_view),
     url(r'^locked/view/with/exception1/', views.locked_view_with_exception),
     url(r'^locked/view/with/exception2/', views.locked_view_with_exception),
+    url(r'^locked/view/with/extra/context/', views.locked_view_with_extra_context),
     url(r'^locked/view/until/yesterday/', views.locked_view_until_yesterday),
     url(r'^locked/view/until/tomorrow/', views.locked_view_until_tomorrow),
     url(r'^locked/view/after/yesterday/', views.locked_view_after_yesterday),

--- a/lockdown/tests/views.py
+++ b/lockdown/tests/views.py
@@ -32,6 +32,12 @@ def locked_view_with_exception(request):
     return HttpResponse('A locked view.')
 
 
+@lockdown(extra_context={'foo': 'bar'})
+def locked_view_with_extra_context(request):
+    """View, locked by the decorator with extra context."""
+    return HttpResponse('A locked view.')
+
+
 @lockdown(until_date=YESTERDAY)
 def locked_view_until_yesterday(request):
     """View, locked till yesterday."""


### PR DESCRIPTION
The owner of a site I'm working on would like parts of the site to only be accessible to authenticated users _or_ users who have been given the access code. I have overridden django-lockdown's template so that instead of just displaying the one form it usually displays, it also displays the standard `AuthenticationForm` from `django.contrib.auth.forms`. So the user is shown a page that says "This Page Requires a User Account or an Access Code" and has both forms. The standard authentication form posts to `{% url 'login' %}?{{ redirect_field_name }}={{ request.path }}`. So my `extra_context` decorator argument looks like this:

``` python
{
    'standard_authentication_form': AuthenticationForm,
    'redirect_field_name': REDIRECT_FIELD_NAME,
}
```

I have also created a receiver function for `django.contrib.auth`'s `user_logged_in` signal:

``` python
@receiver(user_logged_in)
def after_user_logged_in(sender, **kwargs):
    request = kwargs['request']
    request.session['lockdown-allow'] = True
```

This way, authenticated users won't be prompted for the django-lockdown password.

This setup works quite nicely, though it's probably not what django-lockdown is really meant for. However, I'm sure there are other situations where having this `extra_context` decorator argument would be useful.
