### PR TITLE
Updated the code so that it works with Django 1.10rc1

### DIFF
--- a/lockdown/middleware.py
+++ b/lockdown/middleware.py
@@ -4,8 +4,7 @@ from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 
 from lockdown import settings
 
@@ -148,8 +147,7 @@ class LockdownMiddleware(object):
         if self.extra_context is not None:
             page_data.update(self.extra_context)
 
-        return render_to_response('lockdown/form.html', page_data,
-                                  context_instance=RequestContext(request))
+        return render(request, 'lockdown/form.html', page_data)
 
     def redirect(self, request):
         """Utility method to handle redirects."""

--- a/lockdown/tests/test_settings.py
+++ b/lockdown/tests/test_settings.py
@@ -24,3 +24,19 @@ INSTALLED_APPS = (
 )
 
 ROOT_URLCONF = 'lockdown.tests.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/lockdown/tests/test_settings.py
+++ b/lockdown/tests/test_settings.py
@@ -28,7 +28,6 @@ ROOT_URLCONF = 'lockdown.tests.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
The change to "lockdown/middleware.py" is explained in [the "`dictionary` and `context_instance` arguments of rendering functions" section of the Django 1.8 release notes](https://docs.djangoproject.com/en/1.9/releases/1.8/#dictionary-and-context-instance-arguments-of-rendering-functions).

The change to "lockdown/tests/test_settings.py" is explained [here](https://github.com/django/django/blob/1.9.8/django/template/utils.py#L34-L37).
