### PR TITLE
Add x-forward-for support for LOCKDOWN_REMOTE_ADDR_EXCEPTIONS

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@
 - Jan Van Bruggen <jancvanbruggen@gmail.com>
 - Adam Taylor <ataylor32@gmail.com>
 - Piotr Frankowski
+- Jairus Martin

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,25 @@ is in this list, it will not be locked. For example::
         '::1',
     ]
 
+LOCKDOWN_TRUSTED_PROXIES
+-------------------------------
+
+A list of trusted proxy IP-addresses to be used in conjunction with 
+`LOCKDOWN_REMOTE_ADDR_EXCEPTIONS` when a reverse-proxy or load balancer is used.
+If the requesting IP address is from the trusted proxies list the last address from 
+the `X-Forwared-For` header (from `requests.META['HTTP_X_FORWARDED_FOR']`) will be 
+checked against `LOCKDOWN_REMOTE_ADDR_EXCEPTIONS` and locked or unlocked accordingly.
+
+For example::
+
+    LOCKDOWN_TRUSTED_PROXIES = [
+        '172.17.0.1',
+    ]
+    
+    LOCKDOWN_REMOTE_ADDR_EXCEPTIONS = [
+        '172.17.0.5',
+    ]
+
 LOCKDOWN_UNTIL
 --------------
 

--- a/lockdown/settings.py
+++ b/lockdown/settings.py
@@ -4,6 +4,7 @@ ENABLED = getattr(settings, 'LOCKDOWN_ENABLED', True)
 URL_EXCEPTIONS = getattr(settings, 'LOCKDOWN_URL_EXCEPTIONS', ())
 REMOTE_ADDR_EXCEPTIONS = getattr(settings, 'LOCKDOWN_REMOTE_ADDR_EXCEPTIONS',
                                  [])
+TRUSTED_PROXIES = getattr(settings, 'LOCKDOWN_TRUSTED_PROXIES', [])
 PASSWORDS = getattr(settings, 'LOCKDOWN_PASSWORDS', ())
 FORM = getattr(settings, 'LOCKDOWN_FORM', 'lockdown.forms.LockdownForm')
 SESSION_KEY = getattr(settings, 'LOCKDOWN_SESSION_KEY', 'lockdown-allow')


### PR DESCRIPTION
When running behind a reverse proxy server or load balancer the [X-Forwarded-For](https://en.wikipedia.org/wiki/X-Forwarded-For) header is needed to retrieve the IP